### PR TITLE
Add Notion Template Support with Cambridge Pronunciation

### DIFF
--- a/helpers/notion.js
+++ b/helpers/notion.js
@@ -6,16 +6,21 @@ const notion = new Client({
   auth: config.token,
 });
 
-export const createPage = (emoji, properties) => {
-  notion.pages.create({
-    icon: {
-      type: "emoji",
-      emoji,
-    },
-    parent: {
-      type: "database_id",
-      database_id: config.database_id,
-    },
-    properties,
-  });
+export const createPage = async (properties) => {
+  try {
+    const response = await notion.pages.create({
+      parent: {
+        type: "database_id",
+        database_id: config.database_id,
+      },
+      properties,
+      template: {
+        type: "default",
+      },
+    });
+    return response;
+  } catch (error) {
+    console.error("Error creating Notion page:", error.message);
+    throw error;
+  }
 };

--- a/helpers/notion.js
+++ b/helpers/notion.js
@@ -24,3 +24,70 @@ export const createPage = async (properties) => {
     throw error;
   }
 };
+
+export const appendToPage = async (pageId, pronunciations) => {
+  try {
+    const children = [];
+
+    // Add "Pronunciation:" header
+    children.push({
+      object: "block",
+      type: "paragraph",
+      paragraph: {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "Pronunciation:" },
+            annotations: { bold: true },
+          },
+        ],
+      },
+    });
+
+    // Add each pronunciation with audio
+    for (const item of pronunciations) {
+      // Add region and IPA
+      children.push({
+        object: "block",
+        type: "paragraph",
+        paragraph: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: item.region },
+              annotations: { bold: true },
+            },
+            {
+              type: "text",
+              text: { content: `: /${item.ipa}/` },
+            },
+          ],
+        },
+      });
+
+      // Add audio block if available
+      if (item.audioUrl) {
+        children.push({
+          object: "block",
+          type: "audio",
+          audio: {
+            type: "external",
+            external: {
+              url: item.audioUrl,
+            },
+          },
+        });
+      }
+    }
+
+    const response = await notion.blocks.children.append({
+      block_id: pageId,
+      children: children,
+    });
+
+    return response;
+  } catch (error) {
+    console.error("Error appending to Notion page:", error.message);
+    throw error;
+  }
+};

--- a/index.js
+++ b/index.js
@@ -7,7 +7,15 @@ import os from "os";
 import { v4 as uuidv4 } from "uuid";
 import languages from "./languages.js";
 import SocksProxyAgent from "socks-proxy-agent";
-import { createPage } from "./helpers/notion.js";
+import { createPage, appendToPage } from "./helpers/notion.js";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const execFileAsync = promisify(execFile);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const languagePair = new Configstore("language-config-pair");
 const history = new Configstore("translate-history");
@@ -120,6 +128,20 @@ async function validateUrl(url) {
     return false;
   } catch (error) {
     return false;
+  }
+}
+
+async function extractPronunciation(url) {
+  try {
+    const scriptPath = join(__dirname, "scripts", "extract_audio.sh");
+    const { stdout } = await execFileAsync(scriptPath, [url]);
+    const jsonOutput = stdout.trim();
+
+    // Parse and return the JSON array
+    const pronunciations = JSON.parse(jsonOutput);
+    return pronunciations;
+  } catch (error) {
+    return null;
   }
 }
 
@@ -322,8 +344,19 @@ function doTranslate(opts) {
         };
       }
 
-      createPage(properties).catch((error) => {
-        console.error("Failed to create Notion page:", error.message);
-      });
+      // Create the page first
+      createPage(properties)
+        .then(async (page) => {
+          // If we have pronunciation and the page was created successfully, append it to the page content
+          if (linkExists) {
+            const pronunciation = await extractPronunciation(cambridgeUrl);
+            if (pronunciation && page && page.id) {
+              await appendToPage(page.id, pronunciation);
+            }
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to create Notion page:", error.message);
+        });
     });
 }

--- a/index.js
+++ b/index.js
@@ -257,7 +257,6 @@ function doTranslate(opts) {
     })
     .then((res) => {
       // notion
-      var emoji = "📝";
       var properties = {
         Word: {
           title: [
@@ -287,6 +286,8 @@ function doTranslate(opts) {
           ],
         },
       };
-      createPage(emoji, properties);
+      createPage(properties).catch((error) => {
+        console.error("Failed to create Notion page:", error.message);
+      });
     });
 }

--- a/index.js
+++ b/index.js
@@ -347,10 +347,14 @@ function doTranslate(opts) {
       // Create the page first
       createPage(properties)
         .then(async (page) => {
-          // If we have pronunciation and the page was created successfully, append it to the page content
-          if (linkExists) {
+          // If we have a Cambridge link and the page was created successfully, add content
+          if (linkExists && page && page.id) {
+            // Wait a bit for the page/template to be fully initialized
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+
+            // Extract and add pronunciation
             const pronunciation = await extractPronunciation(cambridgeUrl);
-            if (pronunciation && page && page.id) {
+            if (pronunciation) {
               await appendToPage(page.id, pronunciation);
             }
           }

--- a/index.js
+++ b/index.js
@@ -274,31 +274,31 @@ function doTranslate(opts) {
       return res;
     })
     .then((res) => {
-      // // tts
+      // tts
       if (g_config.voice === "remote") {
-        // var fromArray = [];
-        // res.from.text.array.forEach((o) =>
-        //   tts.split(o).forEach((t) => fromArray.push(t))
-        // );
-        // tts.multi(fromArray, {
-        //   to: res.from.language.iso,
-        //   domain: g_config.domain,
-        //   file: res.from.language.ttsfile,
-        //   client: "gtx",
-        //   agent: g_config.agent,
-        //   responseType: "buffer",
-        // });
-        // var toArray = [];
-        // res.to.text.array.forEach((o) =>
-        //   tts.split(o).forEach((t) => toArray.push(t))
-        // );
-        // tts.multi(toArray, {
-        //   to: res.to.language.iso,
-        //   domain: g_config.domain,
-        //   file: res.to.language.ttsfile,
-        //   client: "gtx",
-        //   agent: g_config.agent,
-        // });
+        var fromArray = [];
+        res.from.text.array.forEach((o) =>
+          tts.split(o).forEach((t) => fromArray.push(t))
+        );
+        tts.multi(fromArray, {
+          to: res.from.language.iso,
+          domain: g_config.domain,
+          file: res.from.language.ttsfile,
+          client: "gtx",
+          agent: g_config.agent,
+          responseType: "buffer",
+        });
+        var toArray = [];
+        res.to.text.array.forEach((o) =>
+          tts.split(o).forEach((t) => toArray.push(t))
+        );
+        tts.multi(toArray, {
+          to: res.to.language.iso,
+          domain: g_config.domain,
+          file: res.to.language.ttsfile,
+          client: "gtx",
+          agent: g_config.agent,
+        });
       }
 
       return res;

--- a/index.js
+++ b/index.js
@@ -99,6 +99,30 @@ if (pair) {
   });
 }
 
+async function validateUrl(url) {
+  try {
+    const response = await fetch(url, {
+      method: "HEAD",
+      redirect: "manual", // Don't follow redirects automatically
+    });
+
+    // If status is 200, the page exists
+    // If status is 3xx (redirect), check where it's redirecting to
+    if (response.status === 200) {
+      return true;
+    } else if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      // If redirecting to base dictionary path, word doesn't exist
+      const exists = location && !location.endsWith("/english-spanish/");
+      return exists;
+    }
+
+    return false;
+  } catch (error) {
+    return false;
+  }
+}
+
 function doTranslate(opts) {
   translator
     .translate(opts.text, {
@@ -254,9 +278,16 @@ function doTranslate(opts) {
         //   agent: g_config.agent,
         // });
       }
+
+      return res;
     })
-    .then((res) => {
+    .then(async (res) => {
       // notion
+      const cambridgeUrl = `https://dictionary.cambridge.org/dictionary/english-spanish/${encodeURIComponent(alfy.input)}`;
+
+      // Check if Cambridge link exists
+      const linkExists = await validateUrl(cambridgeUrl);
+
       var properties = {
         Word: {
           title: [
@@ -273,19 +304,24 @@ function doTranslate(opts) {
             name: "New",
           },
         },
-        CambridgeLink: {
+      };
+
+      // Only add Cambridge link if it exists
+      if (linkExists) {
+        properties.CambridgeLink = {
           rich_text: [
             {
               text: {
-                content: `https://dictionary.cambridge.org/dictionary/english-spanish/${encodeURIComponent(alfy.input)}`,
+                content: cambridgeUrl,
                 link: {
-                  url: `https://dictionary.cambridge.org/dictionary/english-spanish/${encodeURIComponent(alfy.input)}`,
+                  url: cambridgeUrl,
                 },
               },
             },
           ],
-        },
-      };
+        };
+      }
+
       createPage(properties).catch((error) => {
         console.error("Failed to create Notion page:", error.message);
       });

--- a/index.js
+++ b/index.js
@@ -304,11 +304,17 @@ function doTranslate(opts) {
       return res;
     })
     .then(async (res) => {
-      // notion
+      // Filter out translations with more than 10 words to not include them in notion
+      if (alfy.input.split(" ").length > 10) {
+        return;
+      }
+
       const cambridgeUrl = `https://dictionary.cambridge.org/dictionary/english-spanish/${encodeURIComponent(alfy.input)}`;
 
-      // Check if Cambridge link exists
-      const linkExists = await validateUrl(cambridgeUrl);
+      // Check if Cambridge link exists only for translations shorter than 3 words
+      const wordCount = alfy.input.split(" ").length;
+      const linkExists =
+        wordCount <= 3 ? await validateUrl(cambridgeUrl) : false;
 
       var properties = {
         Word: {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "alfy"
   ],
   "dependencies": {
-    "@notionhq/client": "^2.1.1",
+    "@notionhq/client": "^5.4.0",
     "alfy": "^2.0.0",
     "configstore": "^6.0.0",
     "got": "^14.0.0",

--- a/scripts/extract_audio.sh
+++ b/scripts/extract_audio.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+
+# Usage:
+#   ./extract_audio.sh "https://dictionary.cambridge.org/dictionary/english-spanish/spur"
+
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "Usage: $0 <cambridge-dictionary-url>" >&2
+  exit 1
+fi
+
+URL="$1"
+
+echo "🔍 Fetching URL: $URL" >&2
+
+# Extract base URL (scheme + host), e.g. https://dictionary.cambridge.org
+BASE_URL=$(printf '%s\n' "$URL" | awk -F/ '{print $1"//"$3}')
+echo "🌐 Base URL: $BASE_URL" >&2
+
+# Download page HTML
+echo "📥 Downloading page HTML..." >&2
+HTML=$(curl -sL -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36" "$URL")
+
+# Check if we got any content
+if [ -z "$HTML" ]; then
+  echo "❌ Error: No HTML content received" >&2
+  exit 1
+fi
+
+echo "✅ Page downloaded ($(echo "$HTML" | wc -c) bytes)" >&2
+
+# Count audio/mpeg occurrences
+AUDIO_COUNT=$(echo "$HTML" | grep -ic 'type="audio/mpeg"' || true)
+echo "🔊 Found $AUDIO_COUNT audio/mpeg elements" >&2
+
+# Count us_pron occurrences
+US_PRON_COUNT=$(echo "$HTML" | grep -ic 'us_pron' || true)
+echo "🇺🇸 Found $US_PRON_COUNT us_pron elements" >&2
+
+# Count uk_pron occurrences
+UK_PRON_COUNT=$(echo "$HTML" | grep -ic 'uk_pron' || true)
+echo "🇬🇧 Found $UK_PRON_COUNT uk_pron elements" >&2
+
+echo "" >&2
+echo "📝 Extracting pronunciation information..." >&2
+
+# Extract UK pronunciation
+UK_AUDIO=$(
+  echo "$HTML" \
+    | grep -i 'type="audio/mpeg"' \
+    | grep 'uk_pron' \
+    | head -n 1 \
+    | sed -n 's/.*src="\([^"]*\)".*/\1/p'
+)
+
+# Extract UK IPA - first IPA in document (UK comes first in Cambridge)
+UK_IPA=$(
+  echo "$HTML" \
+    | grep -o 'class="ipa dipa[^"]*">[^<]*<' \
+    | sed 's/class="ipa dipa[^"]*">//; s/<$//' \
+    | head -n 1
+)
+
+# Extract US pronunciation
+US_AUDIO=$(
+  echo "$HTML" \
+    | grep -i 'type="audio/mpeg"' \
+    | grep 'us_pron' \
+    | head -n 1 \
+    | sed -n 's/.*src="\([^"]*\)".*/\1/p'
+)
+
+# Extract US IPA - second IPA in document
+US_IPA=$(
+  echo "$HTML" \
+    | grep -o 'class="ipa dipa[^"]*">[^<]*<' \
+    | sed 's/class="ipa dipa[^"]*">//; s/<$//' \
+    | sed -n '2p'
+)
+
+# Build JSON output
+JSON_ARRAY="["
+ITEMS_ADDED=0
+
+if [ -n "$UK_IPA" ] || [ -n "$UK_AUDIO" ]; then
+  echo "✅ Found UK pronunciation" >&2
+  [ -n "$UK_IPA" ] && echo "   IPA: $UK_IPA" >&2
+  [ -n "$UK_AUDIO" ] && echo "   Audio: $UK_AUDIO" >&2
+
+  [ $ITEMS_ADDED -gt 0 ] && JSON_ARRAY="${JSON_ARRAY},"
+
+  UK_AUDIO_URL=""
+  if [ -n "$UK_AUDIO" ]; then
+    case "$UK_AUDIO" in
+      http://*|https://*)
+        UK_AUDIO_URL="$UK_AUDIO"
+        ;;
+      *)
+        UK_AUDIO_URL="${BASE_URL}${UK_AUDIO}"
+        ;;
+    esac
+  fi
+
+  JSON_ARRAY="${JSON_ARRAY}{\"region\":\"UK\",\"ipa\":\"$UK_IPA\",\"audioUrl\":\"$UK_AUDIO_URL\"}"
+  ITEMS_ADDED=$((ITEMS_ADDED + 1))
+fi
+
+if [ -n "$US_IPA" ] || [ -n "$US_AUDIO" ]; then
+  echo "✅ Found US pronunciation" >&2
+  [ -n "$US_IPA" ] && echo "   IPA: $US_IPA" >&2
+  [ -n "$US_AUDIO" ] && echo "   Audio: $US_AUDIO" >&2
+
+  [ $ITEMS_ADDED -gt 0 ] && JSON_ARRAY="${JSON_ARRAY},"
+
+  US_AUDIO_URL=""
+  if [ -n "$US_AUDIO" ]; then
+    case "$US_AUDIO" in
+      http://*|https://*)
+        US_AUDIO_URL="$US_AUDIO"
+        ;;
+      *)
+        US_AUDIO_URL="${BASE_URL}${US_AUDIO}"
+        ;;
+    esac
+  fi
+
+  JSON_ARRAY="${JSON_ARRAY}{\"region\":\"US\",\"ipa\":\"$US_IPA\",\"audioUrl\":\"$US_AUDIO_URL\"}"
+  ITEMS_ADDED=$((ITEMS_ADDED + 1))
+fi
+
+JSON_ARRAY="${JSON_ARRAY}]"
+
+if [ $ITEMS_ADDED -eq 0 ]; then
+  echo "❌ No pronunciation information found" >&2
+  exit 1
+fi
+
+echo "" >&2
+echo "📋 Results:" >&2
+echo "$JSON_ARRAY"

--- a/tts.js
+++ b/tts.js
@@ -79,7 +79,7 @@ function single(text, opts) {
       return url + "?" + querystring.stringify(data);
     })
     .then(function (url) {
-      return got(url, { encoding: null, agent: opts.agent })
+      return got(url, { responseType: "buffer", agent: opts.agent })
         .then(function (res) {
           fs.appendFile(opts.file, res.body, function (err) {
             if (err) throw err;


### PR DESCRIPTION
## Changes

- Enhanced Notion integration to append pronunciation data (IPA + audio) from Cambridge Dictionary
- Added bash script to extract UK/US pronunciation and audio URLs from Cambridge pages
- Implemented URL validation to check if Cambridge links exist before adding
- Re-enabled TTS (text-to-speech) functionality
- Filter: only process translations ≤10 words for Notion, only validate Cambridge links for ≤3 words
- Fixed deprecation: replaced `encoding: null` with `responseType: "buffer"` in got library

## Files Modified

- `index.js` - Main translation logic with Notion integration
- `helpers/notion.js` - New `appendToPage()` function
- `tts.js` - Updated got options
- `scripts/extract_audio.sh` - New pronunciation extraction script
