### PR TITLE
Update existing Notion page instead of deleting it

### DIFF
--- a/background-worker.js
+++ b/background-worker.js
@@ -13,6 +13,8 @@ import {
   findAllPagesByWord,
   getLevelValue,
   deletePage,
+  updatePage,
+  clearPageContent,
 } from "./helpers/notion.js";
 import { execFile } from "child_process";
 import { promisify } from "util";
@@ -87,8 +89,10 @@ async function createNotionPage(
     const existingPages = await findAllPagesByWord(word);
     const levelValues = [];
     let highestLevel = 0;
+    let pageToUpdate = null;
 
     if (existingPages.length > 0) {
+      // Collect level values from all existing pages
       for (const page of existingPages) {
         const levelValue = await getLevelValue(page.id);
         if (levelValue) {
@@ -96,20 +100,21 @@ async function createNotionPage(
         }
       }
 
-      // Delete all existing pages
-      for (const page of existingPages) {
-        await deletePage(page.id);
-      }
-
       // Determine the highest level among existing pages
       if (levelValues.length > 0) {
         levelValues.sort((a, b) => b - a); // Descending order
         highestLevel = levelValues[0];
       }
+
+      // Keep the first page to update, delete the rest
+      pageToUpdate = existingPages[0];
+      for (let i = 1; i < existingPages.length; i++) {
+        await deletePage(existingPages[i].id);
+      }
     }
 
-    // Create a new page
-    var properties = {
+    // Prepare properties for the page
+    const properties = {
       Word: {
         title: [{ text: { content: word } }],
       },
@@ -136,7 +141,20 @@ async function createNotionPage(
       };
     }
 
-    const page = await createPage(properties);
+    let page;
+    if (pageToUpdate) {
+      // Update existing page: clear content and update properties
+      await clearPageContent(pageToUpdate.id);
+      page = await updatePage(pageToUpdate.id, properties, "📖");
+    } else {
+      // Create a new page
+      page = await createPage(properties);
+
+      // Set icon for newly created page
+      if (page && page.id) {
+        await updatePage(page.id, {}, "📖");
+      }
+    }
 
     // Add Cambridge data if available
     if (shouldFetchCambridge && page && page.id) {

--- a/helpers/notion.js
+++ b/helpers/notion.js
@@ -122,6 +122,54 @@ export const deletePage = async (pageId) => {
   }
 };
 
+export const updatePage = async (pageId, properties, icon = null) => {
+  try {
+    const updateParams = {
+      page_id: pageId,
+      properties,
+    };
+
+    if (icon) {
+      updateParams.icon = {
+        type: "emoji",
+        emoji: icon,
+      };
+    }
+
+    const response = await notion.pages.update(updateParams);
+    return response;
+  } catch (error) {
+    logError("Error updating Notion page", error);
+    return null;
+  }
+};
+
+export const clearPageContent = async (pageId) => {
+  try {
+    // Get all children blocks of the page
+    const response = await notion.blocks.children.list({
+      block_id: pageId,
+      page_size: 100,
+    });
+
+    // Delete all children blocks
+    for (const block of response.results) {
+      try {
+        await notion.blocks.delete({
+          block_id: block.id,
+        });
+      } catch (error) {
+        logError(`Error deleting block ${block.id}`, error);
+      }
+    }
+
+    return true;
+  } catch (error) {
+    logError("Error clearing page content", error);
+    return false;
+  }
+};
+
 export const appendToPage = async (pageId, data) => {
   try {
     const children = [];


### PR DESCRIPTION
Refactor the page creation process to update an existing Notion page if it exists, rather than deleting it. This includes clearing the content of the existing page before updating its properties. New helper functions for updating and clearing page content have been added.