### PR TITLE
Enhance dictionary extraction with multi-section support

### DIFF
--- a/helpers/notion.js
+++ b/helpers/notion.js
@@ -170,29 +170,83 @@ export const clearPageContent = async (pageId) => {
   }
 };
 
+// Helper function to append blocks in batches (Notion limit: 100 blocks per request)
+async function appendBlocksInBatches(pageId, blocks) {
+  const BATCH_SIZE = 100;
+  let totalAppended = 0;
+
+  for (let i = 0; i < blocks.length; i += BATCH_SIZE) {
+    const batch = blocks.slice(i, i + BATCH_SIZE);
+    try {
+      await notion.blocks.children.append({
+        block_id: pageId,
+        children: batch,
+      });
+      totalAppended += batch.length;
+      console.error(
+        `✅ Appended batch ${Math.floor(i / BATCH_SIZE) + 1} (${
+          batch.length
+        } blocks)`
+      );
+    } catch (error) {
+      logError(`Error appending batch at index ${i}`, error);
+      throw error;
+    }
+  }
+
+  return totalAppended;
+}
+
+// Append blocks with support for toggleable headings with children
+async function appendBlocksWithToggles(pageId, blocksData) {
+  let totalAppended = 0;
+
+  for (const item of blocksData) {
+    if (item.type === "toggle_with_children") {
+      // Append the toggleable heading first
+      const response = await notion.blocks.children.append({
+        block_id: pageId,
+        children: [item.heading],
+      });
+      totalAppended += 1;
+      console.error(
+        `✅ Appended toggleable heading: ${item.heading.heading_2.rich_text[0].text.content}`
+      );
+
+      // Get the ID of the newly created heading block
+      const headingBlockId = response.results[0].id;
+
+      // Append children to the heading in batches
+      const childrenAppended = await appendBlocksInBatches(
+        headingBlockId,
+        item.children
+      );
+      totalAppended += childrenAppended;
+      console.error(`✅ Appended ${childrenAppended} blocks to toggle`);
+    } else {
+      // Regular block - append directly
+      await notion.blocks.children.append({
+        block_id: pageId,
+        children: [item.block],
+      });
+      totalAppended += 1;
+    }
+  }
+
+  return totalAppended;
+}
+
 export const appendToPage = async (pageId, data) => {
   try {
     const children = [];
 
     // Add word information if available
     if (data.wordInfo && data.wordInfo.word) {
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [
-            {
-              type: "text",
-              text: { content: "Word Information:" },
-              annotations: { bold: true },
-            },
-          ],
-        },
-      });
+      const wordInfoBlocks = [];
 
       // Part of speech
       if (data.wordInfo.partOfSpeech) {
-        children.push({
+        wordInfoBlocks.push({
           object: "block",
           type: "paragraph",
           paragraph: {
@@ -213,7 +267,7 @@ export const appendToPage = async (pageId, data) => {
 
       // Word forms
       if (data.wordInfo.wordForms) {
-        children.push({
+        wordInfoBlocks.push({
           object: "block",
           type: "paragraph",
           paragraph: {
@@ -232,37 +286,38 @@ export const appendToPage = async (pageId, data) => {
         });
       }
 
-      // Add spacing
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [],
-        },
-      });
+      // Add heading for Word Information
+      if (wordInfoBlocks.length > 0) {
+        children.push({
+          type: "regular",
+          block: {
+            object: "block",
+            type: "heading_2",
+            heading_2: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: "📖 Word Information" },
+                },
+              ],
+            },
+          },
+        });
+        // Add all word info blocks
+        for (const block of wordInfoBlocks) {
+          children.push({ type: "regular", block });
+        }
+      }
     }
 
     // Add pronunciations if available
     if (data.pronunciations && data.pronunciations.length > 0) {
-      // Add "Pronunciation:" header
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [
-            {
-              type: "text",
-              text: { content: "Pronunciation:" },
-              annotations: { bold: true },
-            },
-          ],
-        },
-      });
+      const pronBlocks = [];
 
       // Add each pronunciation with audio
       for (const item of data.pronunciations) {
         // Add region and IPA
-        children.push({
+        pronBlocks.push({
           object: "block",
           type: "paragraph",
           paragraph: {
@@ -282,7 +337,7 @@ export const appendToPage = async (pageId, data) => {
 
         // Add audio block if available
         if (item.audioUrl) {
-          children.push({
+          pronBlocks.push({
             object: "block",
             type: "audio",
             audio: {
@@ -294,48 +349,330 @@ export const appendToPage = async (pageId, data) => {
           });
         }
       }
-    }
 
-    // Add senses if available
-    if (data.senses && data.senses.length > 0) {
-      // Add "Senses:" header
       children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [
-            {
-              type: "text",
-              text: { content: "Senses:" },
-              annotations: { bold: true },
-            },
-          ],
-        },
-      });
-
-      // Add each sense
-      for (const sense of data.senses) {
-        // Add sense title with level
-        const titleText = sense.level
-          ? `${sense.title} - ${sense.level}`
-          : sense.title;
-
-        children.push({
+        type: "regular",
+        block: {
           object: "block",
-          type: "heading_3",
-          heading_3: {
+          type: "heading_2",
+          heading_2: {
             rich_text: [
               {
                 type: "text",
-                text: { content: titleText },
+                text: { content: "🔊 Pronunciation" },
               },
             ],
           },
-        });
+        },
+      });
+      // Add all pronunciation blocks
+      for (const block of pronBlocks) {
+        children.push({ type: "regular", block });
+      }
+    }
+
+    // Process sections (new structure)
+    if (data.sections && data.sections.length > 0) {
+      console.error(`\n📝 Creating sections with content...`);
+
+      for (const section of data.sections) {
+        const sectionBlocks = [];
+        let totalContent = 0;
+
+        // Add senses if available
+        if (section.senses && section.senses.length > 0) {
+          console.error(
+            `   Adding ${section.senses.length} senses to ${section.name}`
+          );
+          totalContent += section.senses.length;
+
+          // Add each sense
+          for (const [index, sense] of section.senses.entries()) {
+            // Create sense content blocks (without toggle for individual senses)
+            const senseContent = [];
+
+            // Add divider for Global section, or title for CALD section
+            if (section.id === "K-EN-ES-GLOBAL") {
+              // Add horizontal divider for Global section
+              if (index > 0) {
+                // Only add divider before senses after the first one
+                senseContent.push({
+                  object: "block",
+                  type: "divider",
+                  divider: {},
+                });
+              }
+
+              // Add phrase-head as green title if available
+              if (sense.phraseHead) {
+                senseContent.push({
+                  object: "block",
+                  type: "heading_3",
+                  heading_3: {
+                    rich_text: [
+                      {
+                        type: "text",
+                        text: { content: sense.phraseHead },
+                        annotations: { bold: true, color: "green" },
+                      },
+                    ],
+                  },
+                });
+              }
+            } else {
+              // Add title for CALD section
+              let titleText = `${index + 1}. `;
+              if (sense.title) {
+                titleText += sense.title;
+              } else {
+                titleText += "Definition";
+              }
+              if (sense.level) {
+                titleText += ` (${sense.level})`;
+              }
+
+              senseContent.push({
+                object: "block",
+                type: "heading_3",
+                heading_3: {
+                  rich_text: [
+                    {
+                      type: "text",
+                      text: { content: titleText },
+                    },
+                  ],
+                },
+              });
+            }
+
+            // Grammar info
+            if (sense.grammar) {
+              senseContent.push({
+                object: "block",
+                type: "paragraph",
+                paragraph: {
+                  rich_text: [
+                    {
+                      type: "text",
+                      text: { content: `Grammar: ${sense.grammar}` },
+                      annotations: { italic: true, color: "gray" },
+                    },
+                  ],
+                },
+              });
+            }
+
+            // Add definition
+            if (sense.definition) {
+              senseContent.push({
+                object: "block",
+                type: "paragraph",
+                paragraph: {
+                  rich_text: [
+                    {
+                      type: "text",
+                      text: { content: sense.definition },
+                      annotations: { italic: true },
+                    },
+                  ],
+                },
+              });
+            }
+
+            // Add translation
+            if (sense.translation) {
+              senseContent.push({
+                object: "block",
+                type: "callout",
+                callout: {
+                  rich_text: [
+                    {
+                      type: "text",
+                      text: { content: sense.translation },
+                      annotations: { bold: true, color: "blue" },
+                    },
+                  ],
+                },
+              });
+            }
+
+            // Add examples
+            if (sense.examples && sense.examples.length > 0) {
+              senseContent.push({
+                object: "block",
+                type: "paragraph",
+                paragraph: {
+                  rich_text: [
+                    {
+                      type: "text",
+                      text: { content: "Examples:" },
+                      annotations: { bold: true },
+                    },
+                  ],
+                },
+              });
+
+              for (const example of sense.examples) {
+                // English example
+                if (example.en) {
+                  senseContent.push({
+                    object: "block",
+                    type: "bulleted_list_item",
+                    bulleted_list_item: {
+                      rich_text: [
+                        {
+                          type: "text",
+                          text: { content: example.en },
+                        },
+                      ],
+                    },
+                  });
+                }
+
+                // Spanish translation of example
+                if (example.es) {
+                  senseContent.push({
+                    object: "block",
+                    type: "paragraph",
+                    paragraph: {
+                      rich_text: [
+                        {
+                          type: "text",
+                          text: { content: `→ ${example.es}` },
+                          annotations: { italic: true, color: "gray" },
+                        },
+                      ],
+                    },
+                  });
+                }
+              }
+            }
+
+            // Add spacing
+            senseContent.push({
+              object: "block",
+              type: "paragraph",
+              paragraph: {
+                rich_text: [],
+              },
+            });
+
+            sectionBlocks.push(...senseContent);
+          }
+        }
+
+        // Add phrasal verbs if available
+        if (section.phrasalVerbs && section.phrasalVerbs.length > 0) {
+          console.error(
+            `   Adding ${section.phrasalVerbs.length} phrasal verbs to ${section.name}`
+          );
+          totalContent += section.phrasalVerbs.length;
+
+          sectionBlocks.push({
+            object: "block",
+            type: "paragraph",
+            paragraph: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: {
+                    content: `🔗 Phrasal Verbs (${section.phrasalVerbs.length})`,
+                  },
+                  annotations: { bold: true },
+                },
+              ],
+            },
+          });
+
+          for (const phrasalVerb of section.phrasalVerbs) {
+            sectionBlocks.push({
+              object: "block",
+              type: "bulleted_list_item",
+              bulleted_list_item: {
+                rich_text: [
+                  {
+                    type: "text",
+                    text: { content: phrasalVerb },
+                  },
+                ],
+              },
+            });
+          }
+        }
+
+        // Add idioms if available
+        if (section.idioms && section.idioms.length > 0) {
+          console.error(
+            `   Adding ${section.idioms.length} idioms to ${section.name}`
+          );
+          totalContent += section.idioms.length;
+
+          sectionBlocks.push({
+            object: "block",
+            type: "paragraph",
+            paragraph: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: `💡 Idioms (${section.idioms.length})` },
+                  annotations: { bold: true },
+                },
+              ],
+            },
+          });
+
+          for (const idiom of section.idioms) {
+            sectionBlocks.push({
+              object: "block",
+              type: "bulleted_list_item",
+              bulleted_list_item: {
+                rich_text: [
+                  {
+                    type: "text",
+                    text: { content: idiom },
+                  },
+                ],
+              },
+            });
+          }
+        }
+
+        // Add section as toggle only if it has content
+        if (sectionBlocks.length > 0) {
+          children.push({
+            type: "toggle_with_children",
+            heading: {
+              object: "block",
+              type: "heading_2",
+              heading_2: {
+                rich_text: [
+                  {
+                    type: "text",
+                    text: { content: `📚 ${section.name}` },
+                  },
+                ],
+                is_toggleable: true,
+              },
+            },
+            children: sectionBlocks,
+          });
+        }
+      }
+    }
+
+    // Support old structure (backward compatibility)
+    else if (data.senses && data.senses.length > 0) {
+      console.error(
+        `\n📝 Creating ${data.senses.length} sense blocks (old structure)...`
+      );
+
+      // Add each sense as a toggle block
+      for (const [index, sense] of data.senses.entries()) {
+        const senseBlocks = [];
 
         // Add definition
         if (sense.definition) {
-          children.push({
+          senseBlocks.push({
             object: "block",
             type: "paragraph",
             paragraph: {
@@ -352,10 +689,10 @@ export const appendToPage = async (pageId, data) => {
 
         // Add translation
         if (sense.translation) {
-          children.push({
+          senseBlocks.push({
             object: "block",
-            type: "paragraph",
-            paragraph: {
+            type: "callout",
+            callout: {
               rich_text: [
                 {
                   type: "text",
@@ -369,17 +706,31 @@ export const appendToPage = async (pageId, data) => {
 
         // Add examples
         if (sense.examples && sense.examples.length > 0) {
+          senseBlocks.push({
+            object: "block",
+            type: "paragraph",
+            paragraph: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: "Examples:" },
+                  annotations: { bold: true },
+                },
+              ],
+            },
+          });
+
           for (const example of sense.examples) {
             // English example
             if (example.en) {
-              children.push({
+              senseBlocks.push({
                 object: "block",
-                type: "paragraph",
-                paragraph: {
+                type: "bulleted_list_item",
+                bulleted_list_item: {
                   rich_text: [
                     {
                       type: "text",
-                      text: { content: `• ${example.en}` },
+                      text: { content: example.en },
                     },
                   ],
                 },
@@ -388,14 +739,14 @@ export const appendToPage = async (pageId, data) => {
 
             // Spanish translation of example
             if (example.es) {
-              children.push({
+              senseBlocks.push({
                 object: "block",
                 type: "paragraph",
                 paragraph: {
                   rich_text: [
                     {
                       type: "text",
-                      text: { content: `  Trans: ${example.es}` },
+                      text: { content: `→ ${example.es}` },
                       annotations: { italic: true, color: "gray" },
                     },
                   ],
@@ -405,136 +756,117 @@ export const appendToPage = async (pageId, data) => {
           }
         }
 
-        // Add spacing between senses
-        children.push({
-          object: "block",
-          type: "paragraph",
-          paragraph: {
-            rich_text: [],
-          },
-        });
-      }
-    }
+        // Create toggle title
+        const titleText = sense.level
+          ? `${index + 1}. ${sense.title || "Definition"} (${sense.level})`
+          : `${index + 1}. ${sense.title || "Definition"}`;
 
-    // Add phrasal verbs if available
-    if (data.phrasalVerbs && data.phrasalVerbs.length > 0) {
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [
-            {
-              type: "text",
-              text: { content: "Phrasal Verbs:" },
-              annotations: { bold: true },
-            },
-          ],
-        },
-      });
-
-      // Limit to first 10 phrasal verbs to avoid overwhelming the page
-      const phrasalVerbsToShow = data.phrasalVerbs.slice(0, 10);
-      for (const phrasalVerb of phrasalVerbsToShow) {
         children.push({
-          object: "block",
-          type: "bulleted_list_item",
-          bulleted_list_item: {
-            rich_text: [
-              {
-                type: "text",
-                text: { content: phrasalVerb },
-              },
-            ],
-          },
-        });
-      }
-
-      // Add note if there are more
-      if (data.phrasalVerbs.length > 10) {
-        children.push({
-          object: "block",
-          type: "paragraph",
-          paragraph: {
-            rich_text: [
-              {
-                type: "text",
-                text: {
-                  content: `... and ${data.phrasalVerbs.length - 10} more`,
+          type: "toggle_with_children",
+          heading: {
+            object: "block",
+            type: "heading_2",
+            heading_2: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: titleText },
                 },
-                annotations: { italic: true, color: "gray" },
-              },
-            ],
-          },
-        });
-      }
-
-      // Add spacing
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [],
-        },
-      });
-    }
-
-    // Add idioms if available
-    if (data.idioms && data.idioms.length > 0) {
-      children.push({
-        object: "block",
-        type: "paragraph",
-        paragraph: {
-          rich_text: [
-            {
-              type: "text",
-              text: { content: "Idioms:" },
-              annotations: { bold: true },
+              ],
+              is_toggleable: true,
             },
-          ],
-        },
-      });
-
-      // Limit to first 10 idioms
-      const idiomsToShow = data.idioms.slice(0, 10);
-      for (const idiom of idiomsToShow) {
-        children.push({
-          object: "block",
-          type: "bulleted_list_item",
-          bulleted_list_item: {
-            rich_text: [
-              {
-                type: "text",
-                text: { content: idiom },
-              },
-            ],
           },
+          children: senseBlocks,
         });
       }
 
-      // Add note if there are more
-      if (data.idioms.length > 10) {
+      // Add phrasal verbs if available (old structure)
+      if (data.phrasalVerbs && data.phrasalVerbs.length > 0) {
+        const phrasalVerbBlocks = [];
+
+        for (const phrasalVerb of data.phrasalVerbs) {
+          phrasalVerbBlocks.push({
+            object: "block",
+            type: "bulleted_list_item",
+            bulleted_list_item: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: phrasalVerb },
+                },
+              ],
+            },
+          });
+        }
+
         children.push({
-          object: "block",
-          type: "paragraph",
-          paragraph: {
-            rich_text: [
-              {
-                type: "text",
-                text: { content: `... and ${data.idioms.length - 10} more` },
-                annotations: { italic: true, color: "gray" },
-              },
-            ],
+          type: "toggle_with_children",
+          heading: {
+            object: "block",
+            type: "heading_2",
+            heading_2: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: {
+                    content: `🔗 Phrasal Verbs (${data.phrasalVerbs.length})`,
+                  },
+                },
+              ],
+              is_toggleable: true,
+            },
           },
+          children: phrasalVerbBlocks,
+        });
+      }
+
+      // Add idioms if available (old structure)
+      if (data.idioms && data.idioms.length > 0) {
+        const idiomBlocks = [];
+
+        for (const idiom of data.idioms) {
+          idiomBlocks.push({
+            object: "block",
+            type: "bulleted_list_item",
+            bulleted_list_item: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: idiom },
+                },
+              ],
+            },
+          });
+        }
+
+        children.push({
+          type: "toggle_with_children",
+          heading: {
+            object: "block",
+            type: "heading_2",
+            heading_2: {
+              rich_text: [
+                {
+                  type: "text",
+                  text: { content: `💡 Idioms (${data.idioms.length})` },
+                },
+              ],
+              is_toggleable: true,
+            },
+          },
+          children: idiomBlocks,
         });
       }
     }
 
-    const response = await notion.blocks.children.append({
-      block_id: pageId,
-      children: children,
-    });
+    console.error(`\n📦 Total items to append: ${children.length}`);
 
-    return response;
+    // Append blocks with toggle support
+    const totalAppended = await appendBlocksWithToggles(pageId, children);
+
+    console.error(`✅ Successfully appended ${totalAppended} blocks to Notion`);
+
+    return { success: true, blocksAppended: totalAppended };
   } catch (error) {
     logError("Error appending to Notion page", error);
     return null;

--- a/scripts/extract_senses.js
+++ b/scripts/extract_senses.js
@@ -35,8 +35,52 @@ const urlObj = new globalThis.URL(targetUrl);
 const baseURL = urlObj.origin;
 console.error(`🌐 Base URL: ${baseURL}`);
 
-// Extract word information
-console.error("\n📖 Extracting word information...");
+// Find all dictionary sections
+const dictionarySections = [];
+const caldesDiv = document.querySelector('div[data-id="caldes"]');
+const englishSpanishDiv = document.querySelector(
+  'div[data-id="english-spanish"]'
+);
+const globalDiv = document.querySelector('div[data-id="K-EN-ES-GLOBAL"]');
+
+if (caldesDiv) {
+  dictionarySections.push({
+    id: "caldes",
+    name: "English-Spanish (CALD)",
+    div: caldesDiv,
+  });
+  console.error("✅ Found section: English-Spanish (CALD)");
+}
+
+if (englishSpanishDiv) {
+  dictionarySections.push({
+    id: "english-spanish",
+    name: "English-Spanish",
+    div: englishSpanishDiv,
+  });
+  console.error("✅ Found section: English-Spanish");
+}
+
+if (globalDiv) {
+  dictionarySections.push({
+    id: "K-EN-ES-GLOBAL",
+    name: "English-Spanish (Global)",
+    div: globalDiv,
+  });
+  console.error("✅ Found section: English-Spanish (Global)");
+}
+
+if (dictionarySections.length === 0) {
+  console.error("❌ Error: Could not find any dictionary sections");
+  process.exit(1);
+}
+
+console.error(
+  `\n📚 Processing ${dictionarySections.length} dictionary section(s)...\n`
+);
+
+// Extract word information from the first available section
+console.error("📖 Extracting word information...");
 
 const wordInfo = {
   word: "",
@@ -44,31 +88,34 @@ const wordInfo = {
   wordForms: "",
 };
 
-// Extract the main word
-const wordElement = document.querySelector(".di-title");
+// Try to extract from the first section
+const firstSection = dictionarySections[0].div;
+const wordElement = firstSection.querySelector(".di-title, .h2.tw-bw.dhw");
 wordInfo.word = wordElement ? wordElement.textContent.trim() : "";
 if (wordInfo.word) console.error(`   Word: ${wordInfo.word}`);
 
 // Extract part of speech
-const posElement = document.querySelector(".pos.dpos");
+const posElement = firstSection.querySelector(".pos.dpos");
 wordInfo.partOfSpeech = posElement ? posElement.textContent.trim() : "";
 if (wordInfo.partOfSpeech)
   console.error(`   Part of speech: ${wordInfo.partOfSpeech}`);
 
 // Extract word forms (e.g., "running | past ran | past participle run")
-const wordFormsElement = document.querySelector(".irreg-infls, .rreg-infls");
+const wordFormsElement = firstSection.querySelector(
+  ".irreg-infls, .rreg-infls"
+);
 if (wordFormsElement) {
   wordInfo.wordForms = wordFormsElement.textContent.trim();
   console.error(`   Word forms: ${wordInfo.wordForms}`);
 }
 
-// Extract pronunciations
+// Extract pronunciations from first section
 console.error("\n📝 Extracting pronunciation information...");
 
 const pronunciations = [];
 
 // UK pronunciation
-const ukPronContainer = document.querySelector(".uk.dloc");
+const ukPronContainer = firstSection.querySelector(".uk.dloc");
 const ukIpaElement = ukPronContainer
   ? ukPronContainer.parentElement.querySelector(".ipa.dipa")
   : null;
@@ -97,7 +144,7 @@ if (ukIpaElement || ukAudioElement) {
 }
 
 // US pronunciation
-const usPronContainer = document.querySelector(".us.dloc");
+const usPronContainer = firstSection.querySelector(".us.dloc");
 const usIpaElement = usPronContainer
   ? usPronContainer.parentElement.querySelector(".ipa.dipa")
   : null;
@@ -125,143 +172,260 @@ if (usIpaElement || usAudioElement) {
   });
 }
 
-// Extract senses
-console.error("\n📚 Extracting senses...");
+// Process each dictionary section
+const sections = [];
 
-const senseBlocks = document.querySelectorAll(
-  ".sense-block.pr.dsense, .sense-block.pr.dsense-noh"
-);
-const senses = [];
+for (const section of dictionarySections) {
+  console.error(`\n📚 Extracting from ${section.name}...`);
 
-senseBlocks.forEach((block, index) => {
-  console.error(`\n   Sense ${index + 1}:`);
-
-  // Extract sense title (may not exist for dsense-noh blocks)
-  const titleElement = block.querySelector(".sense-title strong.gw");
-  const title = titleElement ? titleElement.textContent.trim() : "";
-  if (title) console.error(`   - Title: ${title}`);
-
-  // Extract CEFR level
-  const levelElement = block.querySelector(".epp-xref.dxref");
-  const level = levelElement ? levelElement.textContent.trim() : "";
-  if (level) console.error(`   - Level: ${level}`);
-
-  // Extract definition
-  const defElement = block.querySelector(".def.ddef_d");
-  const definition = defElement ? defElement.textContent.trim() : "";
-  console.error(`   - Definition: ${definition}`);
-
-  // Extract translation(s) - look in both def-body and trans-block
-  const defBlock = block.querySelector(".def-block.ddef_block");
-  let transElements = [];
-
-  if (defBlock) {
-    // First try to find translations in .def-body (for titled senses)
-    transElements = defBlock.querySelectorAll(
-      ".def-body > .trans.dtrans.dtrans-se"
-    );
-
-    // If not found, look in .trans-block (for untitled senses)
-    if (transElements.length === 0) {
-      transElements = defBlock.querySelectorAll(
-        ".trans-block.dtrans-block > .trans.dtrans.dtrans-se"
-      );
-    }
-  }
-
-  const translations = Array.from(transElements)
-    .map((el) => el.textContent.trim())
-    .filter((t) => t);
-  const translation = translations.join(", ");
-  if (translation) console.error(`   - Translation: ${translation}`);
-
-  // Extract examples
-  const examples = [];
-
-  // Main example with translation
-  const mainExampleElement = block.querySelector(".examp.dexamp .eg.deg");
-  const mainExampleTransElement = block.querySelector(
-    ".examp.dexamp .trans.dtrans.dtrans-se.hdb"
+  const senseBlocks = section.div.querySelectorAll(
+    ".sense-block.pr.dsense, .sense-block.pr.dsense-noh"
   );
+  const senses = [];
 
-  if (mainExampleElement) {
-    const exampleText = mainExampleElement.textContent.trim();
-    const exampleTrans = mainExampleTransElement
-      ? mainExampleTransElement.textContent.trim()
-      : "";
-    examples.push({ en: exampleText, es: exampleTrans });
-    console.error(`   - Main example: ${exampleText}`);
-    if (exampleTrans) console.error(`     Trans: ${exampleTrans}`);
-  }
+  senseBlocks.forEach((block, index) => {
+    // Check if this sense-block has multiple def-blocks (multiple definitions in one sense)
+    const defBlocks = block.querySelectorAll(".def-block.ddef_block");
 
-  // Additional examples (from accordion)
-  const additionalExamples = block.querySelectorAll(".daccord .eg.dexamp.hax");
-  additionalExamples.forEach((exEl) => {
-    const exText = exEl.textContent.trim();
-    examples.push({ en: exText, es: "" });
-    console.error(`   - Additional: ${exText}`);
+    if (defBlocks.length > 1) {
+      // Structure: One sense-block with multiple def-blocks (e.g., "sear")
+      console.error(
+        `   Sense block ${index + 1} has ${defBlocks.length} definitions:`
+      );
+
+      // Extract grammar info once for all definitions (it's at the sense-block level)
+      const grammarElement = block.querySelector(".gram.dgram");
+      const grammar = grammarElement
+        ? grammarElement.textContent.trim().replace(/[\[\]]/g, "")
+        : "";
+      if (grammar) console.error(`   - Grammar: ${grammar}`);
+
+      defBlocks.forEach((defBlock, defIndex) => {
+        console.error(`   Definition ${defIndex + 1}:`);
+
+        // Extract definition
+        const defElement = defBlock.querySelector(".def.ddef_d");
+        const definition = defElement ? defElement.textContent.trim() : "";
+        if (definition) console.error(`   - Definition: ${definition}`);
+
+        // Extract translation(s)
+        let transElements = defBlock.querySelectorAll(
+          ".def-body > .trans.dtrans.dtrans-se"
+        );
+
+        if (transElements.length === 0) {
+          transElements = defBlock.querySelectorAll(
+            ".trans-block.dtrans-block > .trans.dtrans.dtrans-se"
+          );
+        }
+
+        const translations = Array.from(transElements)
+          .map((el) => el.textContent.trim())
+          .filter((t) => t);
+        const translation = translations.join(", ");
+        if (translation) console.error(`   - Translation: ${translation}`);
+
+        // Extract examples from this def-block
+        const examples = [];
+        const seenExamples = new Set();
+
+        const allExamples = defBlock.querySelectorAll(".examp.dexamp");
+        allExamples.forEach((exampBlock) => {
+          const exampleEn = exampBlock.querySelector(".eg.deg");
+          const exampleEs = exampBlock.querySelector(
+            ".trans.dtrans.dtrans-se.hdb"
+          );
+
+          if (exampleEn) {
+            const enText = exampleEn.textContent.trim();
+            const esText = exampleEs ? exampleEs.textContent.trim() : "";
+
+            if (!seenExamples.has(enText)) {
+              seenExamples.add(enText);
+              examples.push({ en: enText, es: esText });
+              console.error(`   - Example: ${enText}`);
+              if (esText) console.error(`     Trans: ${esText}`);
+            }
+          }
+        });
+
+        // Add this definition as a separate sense
+        if (definition) {
+          senses.push({
+            title: "",
+            phraseHead: "",
+            level: "",
+            grammar,
+            definition,
+            translation,
+            examples,
+          });
+        }
+      });
+    } else {
+      // Original structure: One sense-block with one definition
+      console.error(`   Sense ${index + 1}:`);
+
+      // Extract sense title (may not exist for dsense-noh blocks)
+      const titleElement = block.querySelector(".sense-title strong.gw");
+      const title = titleElement ? titleElement.textContent.trim() : "";
+      if (title) console.error(`   - Title: ${title}`);
+
+      // Extract phrase-head for phrase-blocks (used in Global section)
+      const phraseHeadElement = block.querySelector(
+        ".phrase-head .phrase.dphrase"
+      );
+      const phraseHead = phraseHeadElement
+        ? phraseHeadElement.textContent.trim()
+        : "";
+      if (phraseHead) console.error(`   - Phrase: ${phraseHead}`);
+
+      // Extract CEFR level
+      const levelElement = block.querySelector(".epp-xref.dxref");
+      const level = levelElement ? levelElement.textContent.trim() : "";
+      if (level) console.error(`   - Level: ${level}`);
+
+      // Extract grammar info
+      const grammarElement = block.querySelector(".gram.dgram");
+      const grammar = grammarElement
+        ? grammarElement.textContent.trim().replace(/[\[\]]/g, "")
+        : "";
+      if (grammar) console.error(`   - Grammar: ${grammar}`);
+
+      // Extract definition
+      const defElement = block.querySelector(".def.ddef_d");
+      const definition = defElement ? defElement.textContent.trim() : "";
+      if (definition) console.error(`   - Definition: ${definition}`);
+
+      // Extract translation(s) - look in both def-body and trans-block
+      const defBlock = block.querySelector(".def-block.ddef_block");
+      let transElements = [];
+
+      if (defBlock) {
+        // First try to find translations in .def-body (for titled senses)
+        transElements = defBlock.querySelectorAll(
+          ".def-body > .trans.dtrans.dtrans-se"
+        );
+
+        // If not found, look in .trans-block (for untitled senses)
+        if (transElements.length === 0) {
+          transElements = defBlock.querySelectorAll(
+            ".trans-block.dtrans-block > .trans.dtrans.dtrans-se"
+          );
+        }
+      }
+
+      const translations = Array.from(transElements)
+        .map((el) => el.textContent.trim())
+        .filter((t) => t);
+      const translation = translations.join(", ");
+      if (translation) console.error(`   - Translation: ${translation}`);
+
+      // Extract examples
+      const examples = [];
+      const seenExamples = new Set();
+
+      // Look for all example blocks
+      const allExamples = block.querySelectorAll(".examp.dexamp");
+      allExamples.forEach((exampBlock) => {
+        const exampleEn = exampBlock.querySelector(".eg.deg");
+        const exampleEs = exampBlock.querySelector(
+          ".trans.dtrans.dtrans-se.hdb"
+        );
+
+        if (exampleEn) {
+          const enText = exampleEn.textContent.trim();
+          const esText = exampleEs ? exampleEs.textContent.trim() : "";
+
+          // Check if we already have this example
+          if (!seenExamples.has(enText)) {
+            seenExamples.add(enText);
+            examples.push({ en: enText, es: esText });
+            console.error(`   - Example: ${enText}`);
+            if (esText) console.error(`     Trans: ${esText}`);
+          }
+        }
+      });
+
+      // Additional examples (from accordion)
+      const additionalExamples = block.querySelectorAll(
+        ".daccord .eg.dexamp.hax"
+      );
+      additionalExamples.forEach((exEl) => {
+        const exText = exEl.textContent.trim();
+        if (!seenExamples.has(exText)) {
+          seenExamples.add(exText);
+          examples.push({ en: exText, es: "" });
+          console.error(`   - Additional: ${exText}`);
+        }
+      });
+
+      // Add the sense even if there's no title (for adjectives, etc.)
+      if (title || definition || phraseHead) {
+        senses.push({
+          title,
+          phraseHead,
+          level,
+          grammar,
+          definition,
+          translation,
+          examples,
+        });
+      }
+    }
   });
 
-  // Add the sense even if there's no title (for adjectives, etc.)
-  if (title || definition) {
-    senses.push({
-      title,
-      level,
-      definition,
-      translation,
-      examples,
+  console.error(`   ✅ Extracted ${senses.length} senses`);
+
+  // Extract phrasal verbs
+  const phrasalVerbsSection = section.div.querySelector(".xref.phrasal_verbs");
+  const phrasalVerbs = [];
+
+  if (phrasalVerbsSection) {
+    const phrasalVerbLinks =
+      phrasalVerbsSection.querySelectorAll(".item a .phrase");
+    phrasalVerbLinks.forEach((link) => {
+      const phrase = link.textContent.trim();
+      if (phrase) {
+        phrasalVerbs.push(phrase);
+      }
     });
+    if (phrasalVerbs.length > 0) {
+      console.error(`   Found ${phrasalVerbs.length} phrasal verbs`);
+    }
   }
-});
 
-console.error(`\n✅ Extracted ${senses.length} senses`);
+  // Extract idioms
+  const idiomsSection = section.div.querySelector(".xref.idioms");
+  const idioms = [];
 
-// Extract phrasal verbs
-console.error("\n🔗 Extracting phrasal verbs...");
-
-const phrasalVerbsSection = document.querySelector(".xref.phrasal_verbs");
-const phrasalVerbs = [];
-
-if (phrasalVerbsSection) {
-  const phrasalVerbLinks =
-    phrasalVerbsSection.querySelectorAll(".item a .phrase");
-  phrasalVerbLinks.forEach((link) => {
-    const phrase = link.textContent.trim();
-    if (phrase) {
-      phrasalVerbs.push(phrase);
+  if (idiomsSection) {
+    const idiomLinks = idiomsSection.querySelectorAll(".item a .phrase");
+    idiomLinks.forEach((link) => {
+      const phrase = link.textContent.trim();
+      if (phrase) {
+        idioms.push(phrase);
+      }
+    });
+    if (idioms.length > 0) {
+      console.error(`   Found ${idioms.length} idioms`);
     }
+  }
+
+  sections.push({
+    id: section.id,
+    name: section.name,
+    senses,
+    phrasalVerbs,
+    idioms,
   });
-  console.error(`   Found ${phrasalVerbs.length} phrasal verbs`);
-} else {
-  console.error("   No phrasal verbs found");
-}
-
-// Extract idioms
-console.error("\n💡 Extracting idioms...");
-
-const idiomsSection = document.querySelector(".xref.idioms");
-const idioms = [];
-
-if (idiomsSection) {
-  const idiomLinks = idiomsSection.querySelectorAll(".item a .phrase");
-  idiomLinks.forEach((link) => {
-    const phrase = link.textContent.trim();
-    if (phrase) {
-      idioms.push(phrase);
-    }
-  });
-  console.error(`   Found ${idioms.length} idioms`);
-} else {
-  console.error("   No idioms found");
 }
 
 // Output JSON
 const result = {
   wordInfo,
   pronunciations,
-  senses,
-  phrasalVerbs,
-  idioms,
+  sections,
 };
 
 console.error("\n📋 Results:");


### PR DESCRIPTION
## Summary

Improved Cambridge Dictionary extraction to handle multiple dictionary sections (CALD, English-Spanish, Global) and better organize content in Notion with toggle blocks.

## Changes

- **Multi-section support**: Extract from all available dictionary sections (CALD, English-Spanish, Global)
- **Improved structure**: Group definitions by section with toggle headings
- **Enhanced grammar extraction**: Parse and display grammar information for each sense
- **Better example handling**: Deduplicate examples and improve formatting with arrows (→)
- **Notion improvements**: Use callouts for translations and toggle blocks for better organization
- **Multiple definitions**: Handle sense-blocks with multiple def-blocks correctly
